### PR TITLE
Fix wait features to use microseconds

### DIFF
--- a/redir.c
+++ b/redir.c
@@ -102,7 +102,7 @@ static inline ssize_t redir_write(int fd, const void *buf, size_t size, int in)
 		rand_time = rand() % (random_wait * 2);
 		syslog(LOG_DEBUG, "random wait: %u", rand_time);
 		waitbw.tv_sec  = rand_time / 1000;
-		waitbw.tv_usec = rand_time % 1000;
+		waitbw.tv_usec = (rand_time % 1000) * 1000;
 
 		select(1, &empty, NULL, NULL, &waitbw);
 	}
@@ -120,7 +120,7 @@ static inline ssize_t redir_write(int fd, const void *buf, size_t size, int in)
 		bits = size * 8;
 		syslog(LOG_DEBUG, "bandwidth wait: %lu", 1000 * bits / max_bandwidth);
 		waitbw.tv_sec  = bits / max_bandwidth;
-		waitbw.tv_usec = (1000 * (bits % max_bandwidth)) / max_bandwidth;
+		waitbw.tv_usec = (1000000 * (bits % max_bandwidth)) / max_bandwidth;
 
 		select(1, &empty, NULL, NULL, &waitbw);
 	}


### PR DESCRIPTION
Hi there, I found a substantial timing bug when I tried using `redir` to apply a fairly high bandwidth limit. From the commit message:

The wait features (`--random-wait` and `--max-bandwidth`) are based on
the assumption that the 'struct timeval' parameter in 'select' uses
milliseconds for its 'tv_usec' member, but it actually uses
microseconds. This has a dramatic impact on the accuracy of individual
delays below one second - they are too short by a factor of 1000.