### PR TITLE
Add --oob option to redirect Out-of-band data also

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Consult the man page for details.
       -t, --timeout=SEC        Set timeout to SEC seconds, default off (0)
       -v, --version            Show program version
       -x, --connect=STR        CONNECT string passed to proxy server
+      -O, --oob                Redirect Out-of-band data also
     
     Traffic Shaping:
       -m, --max-bandwidth=BPS  Limit the bandwidth to BPS bits/second


### PR DESCRIPTION
I tested this by using Oracle database command line client `sqlplus`.
With this option, typing control + C cancels executing statement immediately. Without it, it needs a few seconds.
